### PR TITLE
Añadir compatibilidad con clientes Windows 10

### DIFF
--- a/webdav.conf
+++ b/webdav.conf
@@ -1,30 +1,99 @@
+dav_ext_lock_zone zone=a:10m;
 
-server {
-    listen 80;
+server { 
+  #server_name webdav.mashnp.sk; 
+  set $webdav_root "/media/";
+  auth_basic "Restricted";
+  auth_basic_user_file /etc/nginx/htpasswd;
+  dav_ext_lock zone=a;
 
-    access_log /dev/stdout;
-    error_log /dev/stdout info;
+  location / {
 
-    client_max_body_size 0;
+	root			$webdav_root;
+	error_page		599 = @propfind_handler;
+	error_page		598 = @delete_handler;
+	error_page		597 = @copy_move_handler;
+	open_file_cache		off;
 
-    location / {
-        create_full_put_path on;
-        autoindex on;
-        autoindex_exact_size off;
-        autoindex_localtime on;
-        charset utf-8;
+	access_log /var/log/nginx/webdav_access.log;
+	error_log /var/log/nginx/webdav_error.log debug;
 
-        dav_methods PUT DELETE MKCOL COPY MOVE;
-        dav_ext_methods PROPFIND OPTIONS;
-        dav_access user:rw group:rw all:rw;
+	send_timeout		3600;
+	client_body_timeout	3600;
+	keepalive_timeout	3600;
+	lingering_timeout	3600;
+	client_max_body_size	10G;
 
-        auth_basic "Restricted";
-    	auth_basic_user_file /etc/nginx/htpasswd;
+	if ($request_method = PROPFIND) {
+		return 599;
+	}
 
-        root /media/;
-        
-        access_log /var/log/nginx/webdav_access.log;
-        error_log /var/log/nginx/webdav_error.log debug;
-        
-    }
+	if ($request_method = PROPPATCH) { # Unsupported, allways return OK.
+		add_header	Content-Type 'text/xml';
+		return		207 '<?xml version="1.0"?><a:multistatus xmlns:a="DAV:"><a:response><a:propstat><a:status>HTTP/1.1 200 OK</a:status></a:propstat></a:response></a:multistatus>';
+	}
+
+	if ($request_method = MKCOL) { # Microsoft specific handle: add trailing slash.
+		rewrite ^(.*[^/])$ $1/ break;
+	}
+
+	if ($request_method = DELETE) {
+		return 598;
+	}
+
+	if ($request_method = COPY) {
+		return 597;
+	}
+
+	if ($request_method = MOVE) {
+		return 597;
+	}
+
+	dav_methods		PUT MKCOL;
+	dav_ext_methods		OPTIONS LOCK UNLOCK;
+	create_full_put_path	on;
+	min_delete_depth	0;
+	dav_access		user:rw group:rw all:rw;
+
+	autoindex		on;
+	autoindex_exact_size	on;
+	autoindex_localtime	on;
+
+	if ($request_method = OPTIONS) {
+		add_header	Allow 'OPTIONS, GET, HEAD, POST, PUT, MKCOL, MOVE, COPY, DELETE, PROPFIND, PROPPATCH, LOCK, UNLOCK';
+		add_header	DAV '1, 2';
+		return 200;
+	}
+  }
+  location @propfind_handler {
+	internal;
+
+	open_file_cache	off;
+	if (!-e $webdav_root/$uri) { # Microsoft specific handle.
+		return 404;
+	}
+	root			$webdav_root;
+	dav_ext_methods		PROPFIND;
+  }
+  location @delete_handler {
+	internal;
+
+	open_file_cache	off;
+	if (-d $webdav_root/$uri) { # Microsoft specific handle: Add trailing slash to dirs.
+		rewrite ^(.*[^/])$ $1/ break;
+	}
+	root			$webdav_root;
+	dav_methods		DELETE;
+  }
+  location @copy_move_handler {
+	internal;
+
+	open_file_cache	off;
+	if (-d $webdav_root/$uri) { # Microsoft specific handle: Add trailing slash to dirs.
+		more_set_input_headers 'Destination: $http_destination/';
+		rewrite ^(.*[^/])$ $1/ break;
+	}
+	root			$webdav_root;
+	dav_methods		COPY MOVE;
+  }
 }


### PR DESCRIPTION
Hola. Tenía problemas al acceder a mi servidor WebDav desde Windows 10. No me dejaba crear ficheros ni directorios. Realmente sí que los creaba pero no me aparecían.

Buscando una solución me encontré con este artículo donde se incluye una configuración que tiene en cuenta las particularidades del cliente WebDav de Windows: https://her01n.com/2021/05/13/webdav-server-with-nginx/

Lo he añadido a tu imagen de WebDav y va como la seda.

La configuración es la misma que aparece en esa web salvo la línea `auth_basic` que lo he dejado como `Restricted`.